### PR TITLE
Track lottery run

### DIFF
--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -352,10 +352,8 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
         qs = sorted(qs, key=lambda o: o.priority, reverse=True)
 
         if not revert:
-            # Set the event-specific setting for the lottery date
             self.request.event.settings.set('main_lottery_date', now().isoformat())
         else:
-            # Delete the event setting when reverting
             self.request.event.settings.delete('main_lottery_date')
 
         headers = [

--- a/src/pretix/control/views/waitinglist.py
+++ b/src/pretix/control/views/waitinglist.py
@@ -351,6 +351,13 @@ class WaitingListView(EventPermissionRequiredMixin, WaitingListQuerySetMixin, Pa
 
         qs = sorted(qs, key=lambda o: o.priority, reverse=True)
 
+        if not revert:
+            # Set the event-specific setting for the lottery date
+            self.request.event.settings.set('main_lottery_date', now().isoformat())
+        else:
+            # Delete the event setting when reverting
+            self.request.event.settings.delete('main_lottery_date')
+
         headers = [
             _('Name'), _('E-mail address'), _('Phone number'), _('Product'), _('On list since'), _('Status'),
             _('Voucher code'),


### PR DESCRIPTION
Track when the lottery has been run by adding a "main_lottery_date" in event.settings. Upon reversion, the property is deleted.