### PR TITLE
Waiting list rank now visible only after lottery has been completed

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/index.html
+++ b/src/pretix/presale/templates/pretixpresale/event/index.html
@@ -230,7 +230,7 @@
         {% endif %}
     {% endif %}
     </main>
-    {% if allow_waitinglist %}
+    {% if allow_waitinglist and event.settings.main_lottery_date %}
         <aside class="front-page" aria-labelledby="check-waiting-list-rank">
             <h3 id="check-waiting-list-rank">{% trans "Check my spot in line" %}</h3>
             {% include "pretixpresale/event/fragment_waitinglist_rank.html" %}


### PR DESCRIPTION
Hide the user's waiting list rank if the lottery hasn't yet been run