### PR TITLE
SID-61: Unnecessary extra closing div was changing formatting

### DIFF
--- a/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
+++ b/src/pretix/presale/templates/pretixpresale/event/fragment_product_list.html
@@ -369,5 +369,4 @@
             {% endif %}
         {% endfor %}
     </section>
-    </div>
 {% endfor %}


### PR DESCRIPTION
https://linear.app/sideburn/issue/SID-61/ticket-purchase-page-ensure-all-ticket-types-have-same-formatting

This is an unmatched and unnecessary closing tag that was breaking formatting for the rest of the page.

After removal:
<img width="1822" height="778" alt="image" src="https://github.com/user-attachments/assets/10b971bf-b43f-478f-b95e-d1b8238770a0" />

I believe it was accidentally added here:
https://github.com/tohyperborea/pretix/commit/bae727ea5ae3fea34a2955808272ebc2f4d3ac2d#diff-6b73808cc2541ee6425b6c04b729e1db61157199d2d5155e33bcba8d9af80732R372
