### PR TITLE
SID-49: Add an option for wait list positions to emails

### DIFF
--- a/src/pretix/base/email.py
+++ b/src/pretix/base/email.py
@@ -594,6 +594,15 @@ def base_placeholders(sender, **kwargs):
             _('Sample Admission Ticket')
         ),
         SimpleFunctionalMailTextPlaceholder(
+            'waiting_list_position', ['waiting_list_entry'],
+            lambda waiting_list_entry: (
+                (lambda p: str(p) if p is not None else '')(
+                    waiting_list_entry.get_rank()
+                )
+            ),
+            '42',
+        ),
+        SimpleFunctionalMailTextPlaceholder(
             'code', ['waiting_list_voucher'], lambda waiting_list_voucher: waiting_list_voucher.code if waiting_list_voucher else '68CYU2H6ZTP3WLK5',
             '68CYU2H6ZTP3WLK5'
         ),


### PR DESCRIPTION
Ticket: [SID-49](https://linear.app/sideburn/issue/SID-49/add-support-for-wait-list-queue-position-to-email-templates)

Adds support for the wait list queue position to wait list email templates. Does not use the ordinal number, just the raw number.