### PR TITLE
SID-40: Allow support for re-joining the waiting list if a voucher has expired

### DIFF
--- a/src/pretix/base/models/waitinglist.py
+++ b/src/pretix/base/models/waitinglist.py
@@ -387,12 +387,14 @@ class WaitingListEntry(LoggedModel):
     @staticmethod
     def clean_duplicate(event, email, item, variation, subevent, pk):
         if WaitingListEntry.objects.filter(
-                item=item, variation=variation, email__iexact=email, voucher__isnull=True, subevent=subevent
+            item=item, variation=variation, email__iexact=email, voucher__isnull=True, subevent=subevent
         ).exclude(pk=pk).count() >= event.settings.waiting_list_limit_per_user:
             raise ValidationError(_('You are already on this waiting list! We will notify '
                                     'you as soon as we have a ticket available for you.'))
         elif WaitingListEntry.objects.filter(
-        item=item, variation=variation, email__iexact=email, voucher__isnull=False, subevent=subevent
-        ).exclude(pk=pk).exists():
+            item=item, variation=variation, email__iexact=email, voucher__isnull=False, subevent=subevent
+        ).exclude(pk=pk).filter(
+            Q(voucher__redeemed__gt=0) | Q(voucher__valid_until__isnull=True) | Q(voucher__valid_until__gte=now())
+        ).exists():
             raise ValidationError(_('You have already been assigned a ticket! '
                                     'Contact ticketing@sideburn.ca if this is in error.'))

--- a/src/tests/base/test_waitinglist.py
+++ b/src/tests/base/test_waitinglist.py
@@ -22,6 +22,7 @@
 from datetime import timedelta
 
 from django.core import mail as djmail
+from django.core.exceptions import ValidationError
 from django.test import TestCase
 from django.utils.timezone import now
 from django_scopes import scope
@@ -130,6 +131,47 @@ class WaitingListTestCase(TestCase):
 
         assert 'foo@bar.com' in wle.voucher.comment
         assert 'Max' in wle.voucher.comment
+
+    @classscope(attr='o')
+    def test_duplicate_allows_expired_unredeemed_voucher(self):
+        v = Voucher.objects.create(
+            event=self.event, valid_until=now() - timedelta(days=1), redeemed=0
+        )
+        WaitingListEntry.objects.create(
+            event=self.event, item=self.item1, email='foo@bar.com', voucher=v
+        )
+        wle = WaitingListEntry(
+            event=self.event, item=self.item1, email='foo@bar.com'
+        )
+        wle.full_clean()
+
+    @classscope(attr='o')
+    def test_duplicate_blocks_redeemed_voucher(self):
+        v = Voucher.objects.create(
+            event=self.event, valid_until=now() - timedelta(days=1), redeemed=1
+        )
+        WaitingListEntry.objects.create(
+            event=self.event, item=self.item1, email='foo@bar.com', voucher=v
+        )
+        wle = WaitingListEntry(
+            event=self.event, item=self.item1, email='foo@bar.com'
+        )
+        with self.assertRaises(ValidationError):
+            wle.full_clean()
+
+    @classscope(attr='o')
+    def test_duplicate_blocks_valid_unredeemed_voucher(self):
+        v = Voucher.objects.create(
+            event=self.event, valid_until=now() + timedelta(days=1), redeemed=0
+        )
+        WaitingListEntry.objects.create(
+            event=self.event, item=self.item1, email='foo@bar.com', voucher=v
+        )
+        wle = WaitingListEntry(
+            event=self.event, item=self.item1, email='foo@bar.com'
+        )
+        with self.assertRaises(ValidationError):
+            wle.full_clean()
 
     def test_send_auto(self):
         with scope(organizer=self.o):


### PR DESCRIPTION
This PR modifies the validation check for duplicate waiting list entries. Previously, if a waiting list entry existed that had any past voucher (even expired) it would prevent a new entry. Now, only a redeemed or currently valid voucher prevents a duplicate entry; if the existing entries have expired/ineffective vouchers, the user can sign up again.

Adds test coverage, though the existing test file has some broken tests due to some pre-existing commented code in the model.