### PR TITLE
SID-86a: Customer account page now displays SMS preferences

### DIFF
--- a/pretix-sideburn-twilio/pretix_twilio_sms/apps.py
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/apps.py
@@ -26,3 +26,17 @@ class PluginApp(PluginConfig):
 
     def ready(self):
         from . import signals  # NOQA
+        self._patch_customer_views()
+
+    def _patch_customer_views(self):
+        from django.apps import apps
+
+        if not apps.is_installed("pretix_twilio_sms"):
+            return
+
+        from pretix.presale.views import customer as presale_customer
+
+        def profile_get_template_names(self):
+            return ["pretix_twilio_sms/customer_profile.html"]
+
+        presale_customer.ProfileView.get_template_names = profile_get_template_names

--- a/pretix-sideburn-twilio/pretix_twilio_sms/templates/pretix_twilio_sms/customer_profile.html
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/templates/pretix_twilio_sms/customer_profile.html
@@ -1,0 +1,15 @@
+{% extends "pretixpresale/organizers/customer_profile.html" %}
+{% load i18n %}
+{% load pretix_twilio_sms_tags %}
+
+{% block customer_profile_after_phone %}
+                {% get_sms_opt_in customer as sms_opt_in %}
+                <dt></dt>
+                <dd>
+                    {% if sms_opt_in %}
+                        <span class="text-success"><i class="fa fa-check" aria-hidden="true"></i> {% trans "You are signed up to receive SMS updates" %}</span>
+                    {% else %}
+                        <span class="text-muted"><i class="fa fa-times" aria-hidden="true"></i> {% trans "You are not signed up to receive SMS updates" %}</span>
+                    {% endif %}
+                </dd>
+{% endblock %}

--- a/pretix-sideburn-twilio/pretix_twilio_sms/templatetags/pretix_twilio_sms_tags.py
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/templatetags/pretix_twilio_sms_tags.py
@@ -1,0 +1,22 @@
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def get_sms_opt_in(customer):
+    """
+    Return True if the customer has opted into SMS updates, False otherwise.
+    Handles missing CustomerSmsPreference (e.g. no record or plugin not installed).
+    """
+    try:
+        from pretix_twilio_sms.models import CustomerSmsPreference
+    except ImportError:
+        return False
+
+    try:
+        return customer.sms_preference.sms_opt_in
+    except CustomerSmsPreference.DoesNotExist:
+        return False
+    except AttributeError:
+        return False

--- a/src/pretix/presale/templates/pretixpresale/organizers/customer_profile.html
+++ b/src/pretix/presale/templates/pretixpresale/organizers/customer_profile.html
@@ -32,6 +32,7 @@
                     <dt>{% trans "Phone" %}</dt>
                     <dd>{{ customer.phone }}</dd>
                 {% endif %}
+                {% block customer_profile_after_phone %}{% endblock %}
             </dl>
             <div class="text-right">
                 <a href="{% eventurl request.organizer "presale:organizer.customer.change" %}"


### PR DESCRIPTION
Added the sms opt in/out info on the customer page.
<img width="688" height="398" alt="image" src="https://github.com/user-attachments/assets/2007fcce-e78c-475f-acbd-88f1cb4980f5" />
