### PR TITLE
SID-89: Twilio webhook sending 'STOP' or 'START' will opt customer in/out

### DIFF
--- a/pretix-sideburn-twilio/pretix_twilio_sms/urls.py
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/urls.py
@@ -1,0 +1,14 @@
+"""
+URL configuration for the pretix Twilio SMS plugin.
+"""
+from django.urls import re_path
+
+from .views import TwilioWebhookView
+
+urlpatterns = [
+    re_path(
+        r"^_twilio_sms/webhook/$",
+        TwilioWebhookView.as_view(),
+        name="webhook",
+    ),
+]

--- a/pretix-sideburn-twilio/pretix_twilio_sms/views.py
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/views.py
@@ -22,11 +22,13 @@ def _get_webhook_auth_token():
     """
     Get the auth token used to validate Twilio webhook signatures.
     Twilio signs requests with the Account Auth Token.
+    Prefers twilio_webhook_auth_token when set; falls back to twilio_auth_token.
     """
     from pretix.base.settings import GlobalSettingsObject
 
     gs = GlobalSettingsObject()
-    return (gs.settings.twilio_auth_token or "").strip()
+    token = (gs.settings.twilio_webhook_auth_token or gs.settings.twilio_auth_token or "").strip()
+    return token
 
 
 def _validate_twilio_request(request):

--- a/pretix-sideburn-twilio/pretix_twilio_sms/views.py
+++ b/pretix-sideburn-twilio/pretix_twilio_sms/views.py
@@ -1,0 +1,178 @@
+"""
+Views for the pretix Twilio SMS plugin.
+"""
+import logging
+
+from django.http import HttpResponse
+from django.utils.decorators import method_decorator
+from django.views import View
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+from django_scopes import scopes_disabled
+
+from pretix_twilio_sms.models import CustomerSmsPreference
+
+logger = logging.getLogger(__name__)
+
+# Empty TwiML response for Twilio webhook.
+TWIML_EMPTY_RESPONSE = '<?xml version="1.0" encoding="UTF-8"?><Response></Response>'
+
+
+def _get_webhook_auth_token():
+    """
+    Get the auth token used to validate Twilio webhook signatures.
+    Twilio signs requests with the Account Auth Token.
+    """
+    from pretix.base.settings import GlobalSettingsObject
+
+    gs = GlobalSettingsObject()
+    return (gs.settings.twilio_auth_token or "").strip()
+
+
+def _validate_twilio_request(request):
+    """
+    Validate the incoming request using Twilio's X-Twilio-Signature header.
+    Returns True if valid or if validation is skipped (no auth token configured).
+    Returns False if validation fails.
+    """
+    auth_token = _get_webhook_auth_token()
+    if not auth_token:
+        logger.warning(
+            "pretix_twilio_sms: Twilio webhook validation skipped - no auth token"
+        )
+        return True
+
+    signature = request.headers.get("X-Twilio-Signature", "")
+    if not signature:
+        logger.warning("pretix_twilio_sms: Twilio webhook missing X-Twilio-Signature")
+        return False
+
+    url = request.build_absolute_uri(request.get_full_path())
+    # Twilio recommends HTTPS for validation; some proxies strip it
+    if url.startswith("http://"):
+        url = "https://" + url[7:]
+
+    try:
+        from twilio.request_validator import RequestValidator
+
+        validator = RequestValidator(auth_token)
+        # RequestValidator.validate(url, params, signature)
+        params = request.POST.copy()
+        if validator.validate(url, params, signature):
+            return True
+    except Exception as e:
+        logger.exception(
+            "pretix_twilio_sms: Twilio webhook validation error: %s", e
+        )
+        return False
+
+    logger.warning("pretix_twilio_sms: Twilio webhook signature invalid")
+    return False
+
+
+def _normalize_phone(phone):
+    """Normalize phone to the same format Customer.phone uses (for filtering)."""
+    if not phone or not phone.strip():
+        return None
+    try:
+        from phonenumber_field.phonenumber import PhoneNumber
+
+        return PhoneNumber.from_string(phone.strip())
+    except Exception:
+        return None
+
+
+def _update_sms_preference_for_phone(phone, sms_opt_in):
+    """
+    Find Customer(s) by phone and update CustomerSmsPreference.
+    Phone may match multiple customers across organizers; we update all.
+    """
+    from pretix.base.models import Customer
+
+    normalized = _normalize_phone(phone)
+    if normalized is None:
+        return 0
+
+    with scopes_disabled():
+        # Search across all organizers (Customer is organizer-scoped)
+        customers = list(
+            Customer.objects.filter(phone=normalized).select_related("organizer")
+        )
+
+        updated = 0
+        for customer in customers:
+            try:
+                pref, created = CustomerSmsPreference.objects.get_or_create(
+                    customer=customer,
+                    defaults={"sms_opt_in": sms_opt_in},
+                )
+                if not created and pref.sms_opt_in != sms_opt_in:
+                    pref.sms_opt_in = sms_opt_in
+                    pref.save()
+                    updated += 1
+                elif created:
+                    updated += 1
+            except Exception as e:
+                logger.exception(
+                    "pretix_twilio_sms: Failed to update CustomerSmsPreference "
+                    "customer_id=%s: %s",
+                    customer.pk,
+                    e,
+                )
+
+    return updated
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+@method_decorator(require_POST, name="dispatch")
+class TwilioWebhookView(View):
+    """
+    Handle Twilio incoming SMS webhooks for STOP/START (opt-out/opt-in).
+
+    When a user replies STOP or START to an SMS, Twilio sends a webhook
+    with OptOutType set. This view maps the From phone number to
+    Customer(s) and updates CustomerSmsPreference accordingly.
+    """
+
+    def post(self, request, *args, **kwargs):
+        if not _validate_twilio_request(request):
+            return HttpResponse(status=403)
+
+        from_phone = (request.POST.get("From") or "").strip()
+        opt_out_type = (request.POST.get("OptOutType") or "").strip().upper()
+
+        if not from_phone:
+            logger.info(
+                "pretix_twilio_sms: Twilio webhook missing From, returning 200"
+            )
+            return HttpResponse(
+                TWIML_EMPTY_RESPONSE,
+                content_type="text/xml",
+            )
+
+        if opt_out_type == "STOP":
+            count = _update_sms_preference_for_phone(from_phone, sms_opt_in=False)
+            logger.info(
+                "pretix_twilio_sms: Twilio STOP from %s, updated %d preference(s)",
+                from_phone,
+                count,
+            )
+        elif opt_out_type == "START":
+            count = _update_sms_preference_for_phone(from_phone, sms_opt_in=True)
+            logger.info(
+                "pretix_twilio_sms: Twilio START from %s, updated %d preference(s)",
+                from_phone,
+                count,
+            )
+        else:
+            # No OptOutType or unknown value - just return empty response
+            logger.debug(
+                "pretix_twilio_sms: Twilio webhook From=%s OptOutType=%s (ignored)",
+                from_phone,
+                opt_out_type or "(empty)",
+            )
+
+        return HttpResponse(
+            TWIML_EMPTY_RESPONSE,
+            content_type="text/xml",
+        )

--- a/pretix-sideburn-twilio/tests/test_twilio_webhook.py
+++ b/pretix-sideburn-twilio/tests/test_twilio_webhook.py
@@ -1,0 +1,179 @@
+"""
+Tests for TwilioWebhookView (STOP/START opt-in/opt-out handling).
+"""
+import pytest
+from django_scopes import scopes_disabled
+
+from pretix.base.models import Customer, Organizer
+from pretix_twilio_sms.models import CustomerSmsPreference
+
+
+TEST_PHONE = "+15551234567"
+
+
+@pytest.fixture(autouse=True)
+def disable_twilio_webhook_signature(monkeypatch):
+    """
+    Disable Twilio signature validation in tests so POSTs are accepted.
+    test_webhook_invalid_signature_returns_403 overrides this to test 403.
+    """
+    monkeypatch.setattr(
+        "pretix_twilio_sms.views._get_webhook_auth_token",
+        lambda: "",
+    )
+
+
+@pytest.fixture
+@scopes_disabled()
+def organizer():
+    return Organizer.objects.create(name="Test Org", slug="testorg")
+
+
+@pytest.fixture
+@scopes_disabled()
+def customer_with_phone(organizer):
+    return organizer.customers.create(
+        email="user@example.com",
+        password="test",
+        is_active=True,
+        is_verified=True,
+        phone=TEST_PHONE,
+    )
+
+
+def _post_webhook(client, From=TEST_PHONE, OptOutType="STOP"):
+    """POST to Twilio webhook with form-urlencoded data."""
+    return client.post(
+        "/_twilio_sms/webhook/",
+        data={"From": From, "OptOutType": OptOutType},
+    )
+
+
+@pytest.mark.django_db
+def test_webhook_stop_creates_preference_with_opt_out(customer_with_phone, client):
+    """STOP creates CustomerSmsPreference with sms_opt_in=False."""
+    response = _post_webhook(client, OptOutType="STOP")
+    print("POST data:", response.wsgi_request.POST)
+    assert response.status_code == 200
+    assert "text/xml" in response["Content-Type"]
+    assert "<Response></Response>" in response.content.decode()
+
+    pref = CustomerSmsPreference.objects.get(customer=customer_with_phone)
+    assert pref.sms_opt_in is False
+
+
+@pytest.mark.django_db
+def test_webhook_start_creates_preference_with_opt_in(customer_with_phone, client):
+    """START creates CustomerSmsPreference with sms_opt_in=True."""
+    response = _post_webhook(client, OptOutType="START")
+    assert response.status_code == 200
+
+    pref = CustomerSmsPreference.objects.get(customer=customer_with_phone)
+    assert pref.sms_opt_in is True
+
+
+@pytest.mark.django_db
+def test_webhook_stop_updates_existing_preference(customer_with_phone, client):
+    """STOP updates existing CustomerSmsPreference from True to False."""
+    CustomerSmsPreference.objects.create(customer=customer_with_phone, sms_opt_in=True)
+
+    response = _post_webhook(client, OptOutType="STOP")
+    assert response.status_code == 200
+
+    pref = CustomerSmsPreference.objects.get(customer=customer_with_phone)
+    assert pref.sms_opt_in is False
+
+
+@pytest.mark.django_db
+def test_webhook_start_updates_existing_preference(customer_with_phone, client):
+    """START updates existing CustomerSmsPreference from False to True."""
+    CustomerSmsPreference.objects.create(customer=customer_with_phone, sms_opt_in=False)
+
+    response = _post_webhook(client, OptOutType="START")
+    assert response.status_code == 200
+
+    pref = CustomerSmsPreference.objects.get(customer=customer_with_phone)
+    assert pref.sms_opt_in is True
+
+
+@pytest.mark.django_db
+def test_webhook_unknown_phone_returns_200(client):
+    """Unknown phone returns 200 and empty TwiML (no Customer match)."""
+    response = _post_webhook(client, From="+15559999999", OptOutType="STOP")
+    assert response.status_code == 200
+    assert CustomerSmsPreference.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_webhook_missing_opt_out_type_returns_200(customer_with_phone, client):
+    """Missing OptOutType returns 200, no preference changes."""
+    response = _post_webhook(client, OptOutType="")
+    assert response.status_code == 200
+    assert not CustomerSmsPreference.objects.filter(customer=customer_with_phone).exists()
+
+
+@pytest.mark.django_db
+def test_webhook_help_ignored(customer_with_phone, client):
+    """OptOutType HELP returns 200, no preference changes."""
+    response = _post_webhook(client, OptOutType="HELP")
+    assert response.status_code == 200
+    assert not CustomerSmsPreference.objects.filter(customer=customer_with_phone).exists()
+
+
+@pytest.mark.django_db
+def test_webhook_missing_from_returns_200(client):
+    """Missing From returns 200 (graceful handling)."""
+    response = client.post(
+        "/_twilio_sms/webhook/",
+        data={"OptOutType": "STOP"},
+        content_type="application/x-www-form-urlencoded",
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+def test_webhook_get_returns_405(client):
+    """GET returns 405 Method Not Allowed."""
+    response = client.get("/_twilio_sms/webhook/")
+    assert response.status_code == 405
+
+
+@pytest.mark.django_db
+def test_webhook_invalid_signature_returns_403(client, monkeypatch):
+    """Invalid/missing signature returns 403 when auth token is configured."""
+    monkeypatch.setattr(
+        "pretix_twilio_sms.views._get_webhook_auth_token",
+        lambda: "secret_token",
+    )
+    response = _post_webhook(client, OptOutType="STOP")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_webhook_stop_updates_multiple_customers_same_phone(organizer, client):
+    """STOP updates all customers with matching phone across organizers."""
+    with scopes_disabled():
+        org2 = Organizer.objects.create(name="Other Org", slug="otherorg")
+    with scopes_disabled():
+        c1 = organizer.customers.create(
+            email="a@example.com",
+            password="x",
+            is_active=True,
+            is_verified=True,
+            phone=TEST_PHONE,
+        )
+        c2 = org2.customers.create(
+            email="b@example.com",
+            password="x",
+            is_active=True,
+            is_verified=True,
+            phone=TEST_PHONE,
+        )
+
+    response = _post_webhook(client, OptOutType="STOP")
+    assert response.status_code == 200
+
+    pref1 = CustomerSmsPreference.objects.get(customer=c1)
+    pref2 = CustomerSmsPreference.objects.get(customer=c2)
+    assert pref1.sms_opt_in is False
+    assert pref2.sms_opt_in is False


### PR DESCRIPTION
This means that if a customer texts 'STOP', they can opt out of texts (and correspondingly use START to resume).