### PR TITLE
SID-95: Improve voucher errors when redeeming an expired voucher that has been used the max # of times

### DIFF
--- a/src/pretix/api/serializers/cart.py
+++ b/src/pretix/api/serializers/cart.py
@@ -148,7 +148,10 @@ class BaseCartPositionCreateSerializer(I18nAwareModelSerializer):
             if voucher and voucher.subevent_id and (not data.get('subevent') or voucher.subevent_id != data['subevent'].pk):
                 raise ValidationError({'voucher': ['The specified voucher is not valid for this subevent.']})
 
-            if voucher.valid_until is not None and voucher.valid_until < now():
+            if voucher.is_fully_redeemed():
+                raise ValidationError({'voucher': ['The specified voucher has already been used the maximum number of times.']})
+
+            if voucher.is_expired():
                 raise ValidationError({'voucher': ['The specified voucher is expired.']})
 
             data['voucher'] = voucher

--- a/src/pretix/api/serializers/order.py
+++ b/src/pretix/api/serializers/order.py
@@ -1239,10 +1239,6 @@ class OrderCreateSerializer(I18nAwareModelSerializer):
                     errs[i]['voucher'] = [error_messages['voucher_invalid_subevent']]
                     continue
 
-                if v.valid_until is not None and v.valid_until < now_dt:
-                    errs[i]['voucher'] = [error_messages['voucher_expired']]
-                    continue
-
                 voucher_usage[v] += 1
                 if voucher_usage[v] > 0:
                     redeemed_in_carts = CartPosition.objects.filter(
@@ -1253,6 +1249,11 @@ class OrderCreateSerializer(I18nAwareModelSerializer):
                         errs[i]['voucher'] = [
                             'The voucher has already been used the maximum number of times.'
                         ]
+                        continue
+
+                if v.is_expired():
+                    errs[i]['voucher'] = [error_messages['voucher_expired']]
+                    continue
 
                 if v.budget is not None:
                     price = pos_data.get('price')

--- a/src/pretix/base/models/vouchers.py
+++ b/src/pretix/base/models/vouchers.py
@@ -551,11 +551,13 @@ class Voucher(LoggedModel):
         Returns True if a voucher has not yet been redeemed, but is still
         within its validity (if valid_until is set).
         """
-        if self.redeemed >= self.max_usages:
-            return False
-        if self.valid_until and self.valid_until < now():
-            return False
-        return True
+        return not self.is_fully_redeemed() and not self.is_expired()
+
+    def is_fully_redeemed(self):
+        return self.redeemed >= self.max_usages
+
+    def is_expired(self):
+        return self.valid_until is not None and self.valid_until < now()
 
     def calculate_price(self, original_price: Decimal, max_discount: Decimal=None) -> Decimal:
         """

--- a/src/pretix/base/services/cart.py
+++ b/src/pretix/base/services/cart.py
@@ -231,7 +231,10 @@ def _get_voucher_availability(event, voucher_use_diff, now_dt, exclude_position_
     for voucher, count in voucher_use_diff.items():
         voucher.refresh_from_db()
 
-        if voucher.valid_until is not None and voucher.valid_until < now_dt:
+        if voucher.is_fully_redeemed():
+            raise CartError(error_messages['voucher_redeemed'])
+
+        if voucher.is_expired():
             raise CartError(error_messages['voucher_expired'])
 
         redeemed_in_carts = CartPosition.objects.filter(
@@ -573,7 +576,9 @@ class CartManager:
         voucher_use_diff = Counter()
         ops = []
 
-        if not voucher.is_active():
+        if voucher.is_fully_redeemed():
+            raise CartError(error_messages['voucher_redeemed'])
+        if voucher.is_expired():
             raise CartError(error_messages['voucher_expired'])
 
         for p in self.positions:

--- a/src/pretix/presale/views/cart.py
+++ b/src/pretix/presale/views/cart.py
@@ -614,9 +614,9 @@ class RedeemView(CustomerRequiredMixin, NoSearchIndexViewMixin, EventViewMixin, 
             v = v.strip()
             try:
                 self.voucher = Voucher.objects.get(code__iexact=v, event=request.event)
-                if self.voucher.redeemed >= self.voucher.max_usages:
+                if self.voucher.is_fully_redeemed():
                     err = error_messages['voucher_redeemed']
-                if self.voucher.valid_until is not None and self.voucher.valid_until < now():
+                elif self.voucher.is_expired():
                     err = error_messages['voucher_expired']
                 if self.voucher.item is not None and self.voucher.item.is_available() is False:
                     err = error_messages['voucher_item_not_available']

--- a/src/pretix/presale/views/widget.py
+++ b/src/pretix/presale/views/widget.py
@@ -718,10 +718,10 @@ class WidgetAPIProductList(EventListMixin, View):
         if 'voucher' in request.GET:
             try:
                 self.voucher = request.event.vouchers.get(code__iexact=request.GET.get('voucher').strip())
-                if self.voucher.redeemed >= self.voucher.max_usages:
+                if self.voucher.is_fully_redeemed():
                     data['error'] = error_messages['voucher_redeemed']
                     fail = True
-                if self.voucher.valid_until is not None and self.voucher.valid_until < now():
+                elif self.voucher.is_expired():
                     data['error'] = error_messages['voucher_expired']
                     fail = True
 

--- a/src/tests/api/test_cart.py
+++ b/src/tests/api/test_cart.py
@@ -1019,6 +1019,27 @@ def test_cartpos_create_with_voucher_redeemed(token_client, organizer, event, it
 
 
 @pytest.mark.django_db
+def test_cartpos_create_with_voucher_redeemed_and_expired_prefers_redeemed(token_client, organizer, event, item, quota):
+    with scopes_disabled():
+        voucher = event.vouchers.create(
+            code="FOOBAR",
+            item=item,
+            redeemed=1,
+            valid_until=now() - datetime.timedelta(days=1),
+        )
+    res = copy.deepcopy(CARTPOS_CREATE_PAYLOAD)
+    res['item'] = item.pk
+    res['voucher'] = voucher.code
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/cartpositions/'.format(
+            organizer.slug, event.slug
+        ), format='json', data=res
+    )
+    assert resp.status_code == 400
+    assert resp.data == {'voucher': ['The specified voucher has already been used the maximum number of times.']}
+
+
+@pytest.mark.django_db
 def test_cartpos_create_bulk_with_voucher(token_client, organizer, event, item, quota):
     with scopes_disabled():
         voucher = event.vouchers.create(code="FOOBAR", item=item, max_usages=3, redeemed=1)

--- a/src/tests/api/test_order_create.py
+++ b/src/tests/api/test_order_create.py
@@ -2695,6 +2695,34 @@ def test_order_create_voucher_expired(token_client, organizer, event, item, quot
 
 
 @pytest.mark.django_db
+def test_order_create_voucher_redeemed_and_expired_prefers_redeemed(token_client, organizer, event, item, quota, question):
+    res = copy.deepcopy(ORDER_CREATE_PAYLOAD)
+    res['positions'][0]['item'] = item.pk
+    res['positions'][0]['answers'][0]['question'] = question.pk
+    del res['positions'][0]['price']
+    with scopes_disabled():
+        voucher = event.vouchers.create(
+            price_mode="set",
+            value=15,
+            item=item,
+            redeemed=1,
+            valid_until=now() - datetime.timedelta(days=1),
+        )
+    res['positions'][0]['voucher'] = voucher.code
+    resp = token_client.post(
+        '/api/v1/organizers/{}/events/{}/orders/'.format(
+            organizer.slug, event.slug
+        ), format='json', data=res
+    )
+    assert resp.status_code == 400
+    assert resp.data == {
+        'positions': [
+            {'voucher': ['The voucher has already been used the maximum number of times.']},
+        ]
+    }
+
+
+@pytest.mark.django_db
 def test_order_create_voucher_block_quota(token_client, organizer, event, item, quota, question):
     res = copy.deepcopy(ORDER_CREATE_PAYLOAD)
     res['positions'][0]['item'] = item.pk

--- a/src/tests/presale/test_event.py
+++ b/src/tests/presale/test_event.py
@@ -855,6 +855,14 @@ class VoucherRedeemItemDisplayTest(EventTestMixin, SoupTest):
         html = self.client.get('/%s/%s/redeem?voucher=%s' % (self.orga.slug, self.event.slug, self.v.code), follow=True)
         assert "alert-danger" in html.rendered_content
 
+    def test_fail_redeemed_and_expired_prefers_redeemed(self):
+        self.v.redeemed = 1
+        self.v.valid_until = now() - datetime.timedelta(days=1)
+        self.v.save()
+        html = self.client.get('/%s/%s/redeem?voucher=%s' % (self.orga.slug, self.event.slug, self.v.code), follow=True)
+        assert "already been used the maximum number of times" in html.rendered_content
+        assert "This voucher is expired." not in html.rendered_content
+
     def test_fail_unknown(self):
         html = self.client.get('/%s/%s/redeem?voucher=%s' % (self.orga.slug, self.event.slug, 'ABC'), follow=True)
         assert "alert-danger" in html.rendered_content


### PR DESCRIPTION
[SID-95](https://linear.app/sideburn/issue/SID-95/your-voucher-expired-on-shows-up-on-an-expired-voucher-that-was)

The voucher expiration error shows up when trying to redeem a voucher that is expired, but has already been used the max amount. The redemption limit should be the more relevant error message, not the expiration.

- Split `voucher.is_active()` into two helper methods to reduce code duplication around redemption/expiration logic
- Add clear voucher redemption limit error messages where there are none (covered by validation already but better to surface here)
- Move the expiration check for vouchers to after the check for redemption limit (more complex check that cross references current carts)
  - This was the primary issue
- Test coverage