### PR TITLE
SID-45: add pretix-passbook plugin to repo + docker image

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "pretix-regex-validation"]
 	path = pretix-regex-validation
 	url = https://github.com/pretix-unofficial/pretix-regex-validation
+[submodule "pretix-passbook"]
+	path = pretix-passbook
+	url = https://github.com/pretix/pretix-passbook.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,7 @@ COPY _build /pretix/_build
 COPY src /pretix/src
 COPY pretix-regex-validation /pretix/pretix-regex-validation
 COPY pretix-sideburn-twilio /pretix/pretix-sideburn-twilio
+COPY pretix-passbook /pretix/pretix-passbook
 
 RUN pip3 install -U \
         pip \
@@ -75,6 +76,11 @@ RUN chmod +x /usr/local/bin/pretix && \
 
 RUN cd /pretix/pretix-regex-validation && \
     ls -al && \
+    pip install -e . && \
+    make && \
+    cd ..
+
+RUN cd /pretix/pretix-passbook && \
     pip install -e . && \
     make && \
     cd ..


### PR DESCRIPTION
## Summary

Adds the `pretix-passbook` as a submodule + installs it in the Docker image. Plugin is pinned to `v1.13.3`, as that's the latest release compatible with our instance of pretix.

## Changes

- add `.gitmodules` entry for `pretix-passbook`
- copy the plugin into the image
- install it in Docker using the same separate plugin build pattern as `pretix-regex-validation`

## Notes

Runtime passbook credentials/configuration are out of scope for this PR, and will be uploaded to the prod instance once live